### PR TITLE
Fix some typos in validation messages

### DIFF
--- a/lib/fileRules.js
+++ b/lib/fileRules.js
@@ -51,7 +51,7 @@ class FileRules {
                 }
             }
         }else{
-            this.validator.addError(field, 'rule', 'size', 'Invalid Arguments provided for the size arguement')
+            this.validator.addError(field, 'rule', 'size', 'Invalid Arguments provided for the size argument')
             success = false;
         }
 

--- a/lib/requiredRules.js
+++ b/lib/requiredRules.js
@@ -60,13 +60,13 @@ class RequiredRules {
                     field,
                     'requiredRule',
                     'requiredIf',
-                    message || 'The '+ field +' has an incorrect number of arguements. The arguements length needs to be a multiple of 2'
+                    message || 'The '+ field +' has an incorrect number of arguments. The arguments length needs to be a multiple of 2'
                 );
 
                 return false;
             }
         }else{
-            this.validator.addError(field, 'requiredRule', 'requiredIf', message || 'The '+ field +' required a minimum of two arguements');
+            this.validator.addError(field, 'requiredRule', 'requiredIf', message || 'The '+ field +' required a minimum of two arguments');
             return false;
         }
     }
@@ -110,12 +110,12 @@ class RequiredRules {
                     field,
                     'requiredRule',
                     'requiredNotIf',
-                    message || 'The '+ field +' has an incorrect number of arguements. The arguements length needs to be a multiple of 2'
+                    message || 'The '+ field +' has an incorrect number of arguments. The arguments length needs to be a multiple of 2'
                 );
                 return false;
             }
         }else{
-            this.validator.addError(field,  'requiredRule', 'requiredNotIf', message || 'The '+ field +' required a minimum of two arguements');
+            this.validator.addError(field,  'requiredRule', 'requiredNotIf', message || 'The '+ field +' required a minimum of two arguments');
             return false;
         }
     }
@@ -140,7 +140,7 @@ class RequiredRules {
 
             return required;
         }else{
-            this.validator.addError(field, 'requiredRule', 'requiredWith', message || 'The '+ field +' requires atleast one other field in the arguement');
+            this.validator.addError(field, 'requiredRule', 'requiredWith', message || 'The '+ field +' requires atleast one other field in the argument');
             return false;
         }
     }
@@ -165,7 +165,7 @@ class RequiredRules {
 
             return required;
         }else{
-            this.validator.addError(field, 'requiredRule', 'requiredWithout', message || 'The '+ field +' requires atleast one other field in the arguement');
+            this.validator.addError(field, 'requiredRule', 'requiredWithout', message || 'The '+ field +' requires atleast one other field in the argument');
             return false;
         }
     }
@@ -190,7 +190,7 @@ class RequiredRules {
 
             return required;
         }else{
-            this.validator.addError(field, 'requiredRule', 'requiredWithAll', message || 'The '+ field +' requires atleast one other field in the arguement');
+            this.validator.addError(field, 'requiredRule', 'requiredWithAll', message || 'The '+ field +' requires atleast one other field in the argument');
             return false;
         }
     }
@@ -215,7 +215,7 @@ class RequiredRules {
 
             return required;
         }else{
-            this.validator.addError(field, 'requiredRule', 'requiredWithoutAll', message || 'The '+ field +' requires atleast one other field in the arguement');
+            this.validator.addError(field, 'requiredRule', 'requiredWithoutAll', message || 'The '+ field +' requires atleast one other field in the argument');
             return false;
         }
     }

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -45,13 +45,13 @@ class Rules {
         }
 
         if(!mAfterDate.isValid()){
-            this.validator.addError(field, 'rule', 'after', 'The after date arguement is an invalid date');
+            this.validator.addError(field, 'rule', 'after', 'The after date argument is an invalid date');
             return false;
         }else if(!mDate.isValid()){
             this.validator.addError(field, 'rule', 'after', 'The value of the field is an invalid date');
             return false;
         }else if(mAfterDate.valueOf() > mDate.valueOf()){
-            this.validator.addError(field, 'rule', 'after', message || 'The provided date does not fall after the date mentioned in the arguement');
+            this.validator.addError(field, 'rule', 'after', message || 'The provided date does not fall after the date mentioned in the argument');
             return false;
         }
 
@@ -100,13 +100,13 @@ class Rules {
         }
 
         if(!mBeforeDate.isValid()){
-            this.validator.addError(field, 'rule', 'before', message || 'The before date arguement is an invalid date');
+            this.validator.addError(field, 'rule', 'before', message || 'The before date argument is an invalid date');
             return false;
         }else if(!mDate.isValid()){
             this.validator.addError(field, 'rule', 'before', message || 'The value of the field is an invalid date');
             return false;
         }else if(mBeforeDate.valueOf() < mDate.valueOf()){
-            this.validator.addError(field, 'rule', 'before', message || 'The provided date does not come before the date mentioned in the arguement');
+            this.validator.addError(field, 'rule', 'before', message || 'The provided date does not come before the date mentioned in the argument');
             return false;
         }
 
@@ -117,14 +117,14 @@ class Rules {
     * between(field, value, args, message){
 
         if(!Array.isArray(args) && args.length !== 2){
-            this.validator.addError(field, 'rule', 'between', 'The number of arguements in the field are invalid');
+            this.validator.addError(field, 'rule', 'between', 'The number of arguments in the field are invalid');
             return false;
         }else{
             if(!v.isInt(args[0]) || !v.isInt(args[1])){
-                this.validator.addError(field, 'rule', 'between', 'The rule arguements for the field need to be integers');
+                this.validator.addError(field, 'rule', 'between', 'The rule arguments for the field need to be integers');
                 return false;
             }else if( parseInt(args[0]) >= parseInt(args[1]) ){
-                this.validator.addError(field, 'rule', 'between', 'The rule arguement for the min value cannot be greater than or equal to the max value');
+                this.validator.addError(field, 'rule', 'between', 'The rule argument for the min value cannot be greater than or equal to the max value');
                 return false;
             }else if(value.toString().length < parseInt(args[0]) || value.toString().length > parseInt(args[1])){
                 if(message){
@@ -152,7 +152,7 @@ class Rules {
 
     * contains(field, value, inString, message){
         if(typeof inString !== "string"){
-            this.validator.addError(field, 'rule', 'contains', 'The number of arguements provided is invalid. Please provide one single string');
+            this.validator.addError(field, 'rule', 'contains', 'The number of arguments provided is invalid. Please provide one single string');
             return false;
         }else{
             if(!v.contains(value, inString)){
@@ -191,7 +191,7 @@ class Rules {
 
     * different(field, value, otherField, message){
         if(typeof otherField !== "string"){
-            this.validator.addError(field, 'rule', 'different', 'The number of arguements provided is invalid. Please provide one single string');
+            this.validator.addError(field, 'rule', 'different', 'The number of arguments provided is invalid. Please provide one single string');
             return false;
         }else{
             otherField = otherField.split('.').filter(function(e){ return e !== ''; });
@@ -225,7 +225,7 @@ class Rules {
         }
 
         if(!v.isInt(dNumber)){
-            this.validator.addError(field, 'rule', 'digits', 'The arguement entered is an invalid. Please enter digits');
+            this.validator.addError(field, 'rule', 'digits', 'The argument entered is an invalid. Please enter digits');
             return false;
         }else if(value != dNumber){
             this.validator.addError(field, 'rule', 'digits', message || 'The value does not match with the mentioned number');
@@ -246,14 +246,14 @@ class Rules {
 
     * digitsBetween(field, value, args, message){
         if(!Array.isArray(args) && args.length !== 2){
-            this.validator.addError(field, 'rule', 'digitsBetween', 'The number of arguements in the field are invalid');
+            this.validator.addError(field, 'rule', 'digitsBetween', 'The number of arguments in the field are invalid');
             return false;
         }else{
             if(!v.isInt(args[0]) || !v.isInt(args[1])){
-                this.validator.addError(field, 'rule', 'digitsBetween', 'The rule arguements for the field need to be integers');
+                this.validator.addError(field, 'rule', 'digitsBetween', 'The rule arguments for the field need to be integers');
                 return false;
             }else if(parseInt(args[0]) >= parseInt(args[1])){
-                this.validator.addError(field, 'rule', 'digitsBetween', 'The rule arguement for the min value cannot be greater than or equal to the max value');
+                this.validator.addError(field, 'rule', 'digitsBetween', 'The rule argument for the min value cannot be greater than or equal to the max value');
                 return false;
             }else if(parseInt(value) < parseInt(args[0]) || parseInt(value) > parseInt(args[1])){
                 if(message){
@@ -279,7 +279,7 @@ class Rules {
 
     * equals(field, value, arg, message){
         if(value != arg){
-            this.validator.addError(field, 'rule', 'equals', message || 'The value entered does not match with the arguement');
+            this.validator.addError(field, 'rule', 'equals', message || 'The value entered does not match with the argument');
             return false;
         }
 
@@ -298,7 +298,7 @@ class Rules {
         }
 
         if(!match){
-            this.validator.addError(field, 'rule', 'in', message || 'The value entered does not exist in the arguements supplied');
+            this.validator.addError(field, 'rule', 'in', message || 'The value entered does not exist in the arguments supplied');
             return false;
         }
 
@@ -334,13 +334,13 @@ class Rules {
 
     * max(field, value, maxNum, message){
         if(!v.isInt(maxNum)){
-            this.validator.addError(field, 'rule', 'max', message || 'The rule arguements for max fields needs to be an integer');
+            this.validator.addError(field, 'rule', 'max', message || 'The rule arguments for max fields needs to be an integer');
             return false;
         }else if(parseInt(value) > parseInt(maxNum)){
             if(message){
                 message.replace(':max', maxNum)
             }
-            this.validator.addError(field, 'rule', 'max', message || 'The value of the field is greater than the max arguement');
+            this.validator.addError(field, 'rule', 'max', message || 'The value of the field is greater than the max argument');
             return false;
         }
 
@@ -349,13 +349,13 @@ class Rules {
 
     * maxLength(field, value, maxNum, message){
         if(!v.isInt(maxNum)){
-            this.validator.addError(field, 'rule', 'max', message || 'The rule arguements for max fields needs to be an integer');
+            this.validator.addError(field, 'rule', 'max', message || 'The rule arguments for max fields needs to be an integer');
             return false;
         }else if(value.toString().length > parseInt(maxNum)){
             if(message){
                 message.replace(':maxLength', maxNum)
             }
-            this.validator.addError(field, 'rule', 'maxLength', message || 'The size of the field is greater than the max arguement');
+            this.validator.addError(field, 'rule', 'maxLength', message || 'The size of the field is greater than the max argument');
             return false;
         }
 
@@ -364,14 +364,14 @@ class Rules {
 
     * min(field, value, minNum, message){
         if(!v.isInt(minNum)){
-            this.validator.addError(field, 'rule', 'min', message || 'The rule arguements for min fields needs to be an integer');
+            this.validator.addError(field, 'rule', 'min', message || 'The rule arguments for min fields needs to be an integer');
             return false;
         }else if(parseInt(value) < parseInt(minNum)){
             if(message){
                 message.replace(':min', minNum)
             }
 
-            this.validator.addError(field, 'rule', 'min', message || 'The value of the field is lesser than the min arguement');
+            this.validator.addError(field, 'rule', 'min', message || 'The value of the field is lesser than the min argument');
             return false;
         }
 
@@ -380,14 +380,14 @@ class Rules {
 
     * minLength(field, value, minNum, message){
         if(!v.isInt(minNum)){
-            this.validator.addError(field, 'rule', 'min', 'The rule arguements for min fields needs to be an integer');
+            this.validator.addError(field, 'rule', 'min', 'The rule arguments for min fields needs to be an integer');
             return false;
         }else if(value.toString().length < parseInt(minNum)){
             if(message){
                 message.replace(':minLength', minNum)
             }
 
-            this.validator.addError(field, 'rule', 'minLength', message || 'The size of the field is lesser than the min arguement');
+            this.validator.addError(field, 'rule', 'minLength', message || 'The size of the field is lesser than the min argument');
             return false;
         }
 
@@ -396,7 +396,7 @@ class Rules {
 
     * notContains(field, value, inString, message){
         if(typeof inString !== "string"){
-            this.validator.addError(field, 'rule', 'notContains', 'The number of arguements provided is invalid. Please provide one single string');
+            this.validator.addError(field, 'rule', 'notContains', 'The number of arguments provided is invalid. Please provide one single string');
             return false;
         }else{
             if(v.contains(value, inString)){
@@ -424,7 +424,7 @@ class Rules {
         }
 
         if(!noMatch){
-            this.validator.addError(field, 'rule', 'notIn', message || 'The value entered exists in the arguements supplied');
+            this.validator.addError(field, 'rule', 'notIn', message || 'The value entered exists in the arguments supplied');
             return false;
         }
 
@@ -442,7 +442,7 @@ class Rules {
 
     * regex(field, value, regexp, message){
         if(!(regexp instanceof RegExp)){
-            this.validator.addError(field, 'rule', 'regex', message || 'The regex arguement is not a valid regular expression');
+            this.validator.addError(field, 'rule', 'regex', message || 'The regex argument is not a valid regular expression');
             return false;
         }else if(!regexp.test(value)){
             if(message){
@@ -458,7 +458,7 @@ class Rules {
 
     * same(field, value, otherField, message){
         if(typeof otherField !== 'string'){
-            this.validator.addError(field, 'rule', 'same', message || 'The number of arguements provided is invalid. Please provide one single string');
+            this.validator.addError(field, 'rule', 'same', message || 'The number of arguments provided is invalid. Please provide one single string');
             return false;
         }else{
             otherField = otherField.split('.').filter(function(e){ return e !== ''; });


### PR DESCRIPTION
Changed 'arguement' to 'argument' in the *rules.js files.
